### PR TITLE
refactor: Enhance styles for AboutEvent, Schedule,and Ticket components for better responsiveness

### DIFF
--- a/src/components/AboutEvent/styles.module.scss
+++ b/src/components/AboutEvent/styles.module.scss
@@ -28,6 +28,7 @@
   }
   .container {
     display: flex;
+    width: 100%;
     gap: 24px;
     justify-content: center;
   }
@@ -44,6 +45,8 @@
     padding: 0 0 30px 50px;
     align-self: self-end;
   }
+ 
+
 }
 
 .card {
@@ -129,7 +132,7 @@
 @media (max-width: 480px) {
   .aboutEvent {
     .container {
-      flex-direction: column;
+    //   flex-direction: column;
       align-items: center;
     }
     div > h1 {
@@ -139,10 +142,34 @@
       align-self: center;
       width: 300px;
     }
+    .card {
+      width: 200px;
+      height: auto;
+      h2 {
+        font-size: 24px;
+      }
+      p {
+        font-size: 14px;
+      }
+    }
   }
+//   .aboutEvent {
+//     align-items: center;
+//   }
 
-  .card {
-    min-width: none;
-    width: 90%;
-  }
+ 
 }
+
+// @media screen and (max-width: 362px) {
+//     .card{
+
+//         width: 250px;
+//         height: auto;
+//         h2 {
+//             font-size: 24px;
+//     }
+//     p {
+//       font-size: 14px;
+//     }
+// }
+// }

--- a/src/components/Schedule/styles.module.scss
+++ b/src/components/Schedule/styles.module.scss
@@ -218,3 +218,17 @@
 	}
 	
 }
+
+@media (max-width: 362px) {
+    .schedule{
+        .scheduleItem {
+            div {
+                width: 200px;
+                h2 {
+                    font-size: 20px;
+                }
+                
+            }
+        }
+    }
+}

--- a/src/shared/Ticket/styles.module.scss
+++ b/src/shared/Ticket/styles.module.scss
@@ -68,7 +68,7 @@
   .ticket {
     .card {
       img {
-        width: 342px;
+        width: 300px;
       }
     }
   }


### PR DESCRIPTION
This pull request includes several changes to the styling of components in the `styles.module.scss` files. The most important changes involve adjustments to layout and media queries to improve responsiveness and consistency across different screen sizes.

### Adjustments to `AboutEvent` component styles:

* [`src/components/AboutEvent/styles.module.scss`](diffhunk://#diff-9f6bb20922f2f9d995be02d97fea1cfa22c087f279fd6595a359a2c81cb15428R31): Set the `.container` width to 100% to ensure it spans the full width of its parent.
* [`src/components/AboutEvent/styles.module.scss`](diffhunk://#diff-9f6bb20922f2f9d995be02d97fea1cfa22c087f279fd6595a359a2c81cb15428L132-R135): Commented out the `flex-direction: column` rule in the `.container` for screens with a max-width of 480px, aligning items to the center instead.
* [`src/components/AboutEvent/styles.module.scss`](diffhunk://#diff-9f6bb20922f2f9d995be02d97fea1cfa22c087f279fd6595a359a2c81cb15428L142-R175): Updated the `.card` width to 200px and added font-size adjustments for `h2` and `p` elements within the `.card` for better readability on smaller screens.

### Adjustments to `Schedule` component styles:

* [`src/components/Schedule/styles.module.scss`](diffhunk://#diff-46660cd4385ddededa2f65de18e57c0ab2e1aed1405572138f615c6064989f88R221-R234): Added a media query for screens with a max-width of 362px to adjust the width of `.scheduleItem` and font-size of `h2` elements within `.scheduleItem` for better responsiveness.

### Adjustments to `Ticket` component styles:

* [`src/shared/Ticket/styles.module.scss`](diffhunk://#diff-9af349d72c18fff03845dc0c3084a8dc37cfc65a4c587d2b0c286344c56ba49dL71-R71): Reduced the width of `img` elements within `.card` from 342px to 300px for better scaling on smaller screens.