### PR TITLE
never read build fix

### DIFF
--- a/src/pages/Shop/index.tsx
+++ b/src/pages/Shop/index.tsx
@@ -1,6 +1,6 @@
 import styles from "./styles.module.scss";
-import { Button } from "../../components/Button";
-import { Icon } from "../../components/icons";
+// import { Button } from "../../components/Button";
+// import { Icon } from "../../components/icons";
 import { Header } from "../../shared/header";
 
 export function Shop() {


### PR DESCRIPTION
This pull request includes a minor change in the `src/pages/Shop/index.tsx` file. The change comments out the import statements for `Button` and `Icon` components, which are no longer used in the `Shop` component.

* [`src/pages/Shop/index.tsx`](diffhunk://#diff-c9974fe856809955c218775a58ca7e3be6f3bbd7209f2f3e9322b2edde035a61L2-R3): Commented out the import statements for `Button` and `Icon` components.