### PR TITLE
Feature/o que esperar

### DIFF
--- a/src/pages/o-que-esperar/o-que-esperar.module.scss
+++ b/src/pages/o-que-esperar/o-que-esperar.module.scss
@@ -21,7 +21,6 @@
             color: #666666;
         }
         span{
-            cursor: pointer;
             font-family: Montserrat;
             font-size: 16px;
             font-weight: 700;

--- a/src/shared/Footer/index.tsx
+++ b/src/shared/Footer/index.tsx
@@ -46,7 +46,7 @@ export default function Footer() {
             <a href="/sescomp/#/#about" onClick={handleScrollAbout}>Conheça a SESCOMP</a>
           </li>
           <li>
-            <a href="/sescomp/#/em-breve" onClick={scrollToTop}>O que esperar?</a>
+            <a href="/sescomp/#/o-que-esperar" onClick={scrollToTop}>O que esperar?</a>
           </li>
           <li>
             <a href="/sescomp/#/#speakers" onClick={handleScrollToSpeakers}>Palestrantes</a>


### PR DESCRIPTION
This pull request includes a few changes to the styling and navigation of the "O que esperar" page and the footer component.

Styling update:

* [`src/pages/o-que-esperar/o-que-esperar.module.scss`](diffhunk://#diff-ddd16ffc42f82c34bc8c93d0b8e0c42dae34ece26c676d7928873c041f182e38L24): Removed the `cursor: pointer;` style from the `span` element.

Navigation update:

* [`src/shared/Footer/index.tsx`](diffhunk://#diff-34dbf863763a269117a03b54d1d89d60e35684e0eba2f2d72920401edbceccfeL49-R49): Updated the link for "O que esperar?" to point to the correct section (`/o-que-esperar`).