### PR TITLE
chore: Update "OQueEsperar" page layout and styles

### DIFF
--- a/src/pages/o-que-esperar/o-que-esperar.module.scss
+++ b/src/pages/o-que-esperar/o-que-esperar.module.scss
@@ -216,7 +216,12 @@
 
 @media screen and (max-width: 768px) {
     .OQueEsperar {
-        padding: 120px 16px;
+        padding: 100px 16px;
+        gap: 64px;
+        .indicator{
+            padding-bottom: 0;
+        }
+
         .infoContainer {
             .info {
                 width: 90vw;


### PR DESCRIPTION
This pull request includes a small change to the `src/pages/o-que-esperar/o-que-esperar.module.scss` file to adjust the styling for mobile screens.

Styling adjustments for mobile screens:

* Changed padding for the `.OQueEsperar` class from `120px 16px` to `100px 16px` and added a `gap` of `64px`.
* Added a rule to set `padding-bottom` to `0` for the `.indicator` class within `.OQueEsperar`.